### PR TITLE
关于jdk11升级后相关依赖存在反射警告的解决

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,20 +16,19 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <lombok.version>1.18.8</lombok.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
         <logback.version>1.2.3</logback.version>
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
-        <retrofit.version>2.9.0</retrofit.version>
+        <retrofit.version>2.7.2</retrofit.version>
         <logging-interceptor.version>3.14.9</logging-interceptor.version>
         <fastjson.version>1.2.73</fastjson.version>
         <converter-gson.version>2.9.0</converter-gson.version>
         <commons-lang3.version>3.9</commons-lang3.version>
-        <javassist.version>3.25.0-GA</javassist.version>
+        <javassist.version>3.23.1-GA</javassist.version>
         <pulsar-client.version>2.5.0</pulsar-client.version>
-        <javassist.version>3.25.0-GA</javassist.version>
         <spring-boot.version>2.1.1.RELEASE</spring-boot.version>
     </properties>
 


### PR DESCRIPTION
对一些有问题的依赖版本进行了降低，警告信息消失了，并且能够正常进行云云连接 但是还没有很充分的测试不清楚有没有别的一些影响