### PR TITLE
Add compatibility with Spring Boot 3.0

### DIFF
--- a/connector-spring-boot/connector-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/connector-spring-boot/connector-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.tuya.connector.spring.boot.autoconfigure.ConnectorAutoConfiguration
+com.tuya.connector.spring.boot.autoconfigure.ConnectorExportAutoConfiguration


### PR DESCRIPTION
This PR adds support for registering auto-configuration classes using `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`, which was added in Spring Boot 2.7 as a replacement for `org.springframework.boot.autoconfigure.EnableAutoConfiguration` key in `META-INF/spring.factories`.

Additionally, Spring Boot 3.0 removed support for discovering auto-configuration classes using `META-INF/spring.factories` so `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` is required in order for auto-configuration classes to be discovered.

See here for more details:
- https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#auto-configuration-registration
- https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files